### PR TITLE
Fix: remove duplicate style tag in layout.svelte #50

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,65 +1,62 @@
 <script>
-	import favicon from '$lib/assets/favicon.svg';
-	
-	let { children } = $props();
+    import favicon from "$lib/assets/favicon.svg";
+
+    let { children } = $props();
 </script>
-
-<style>
-	    :root {
-    /* Primary colors */
-    --primary-color-0:  hsl(200, 43%, 0%);
-    --primary-color-10: hsl(200, 43%, 10%);
-    --primary-color:    hsl(200, 43%, 20%);
-    --primary-color-30: hsl(200, 43%, 30%);
-    --primary-color-40: hsl(200, 43%, 40%);
-    --primary-color-50: hsl(200, 43%, 50%);
-    --primary-color-60: hsl(200, 43%, 60%);
-
-    /* Accent colors */
-    --accent-green-80: hsl(136, 100%, 80%);
-    --accent-green-70: hsl(136, 100%, 70%);
-    --accent-green-60: hsl(136, 100%, 60%);
-    --accent-green:    hsl(136, 100%, 50%);
-    --accent-green-40: hsl(136, 100%, 40%);
-    --accent-green-30: hsl(136, 100%, 30%);
-    --accent-green-20: hsl(136, 100%, 20%);
-
-    --accent-red-90: hsl(357, 100%, 90%);
-    --accent-red-80: hsl(357, 100%, 80%);
-    --accent-red-70: hsl(357, 100%, 70%);
-    --accent-red:    hsl(357, 100%, 60%);
-    --accent-red-50: hsl(357, 100%, 50%);
-    --accent-red-40: hsl(357, 100%, 40%);
-    --accent-red-30: hsl(357, 100%, 30%);
-
-    --accent-yellow-80: hsl(55, 94%, 80%);
-    --accent-yellow-70: hsl(55, 94%, 70%);
-    --accent-yellow-60: hsl(55, 94%, 60%);
-    --accent-yellow:    hsl(55, 94%, 50%);
-    --accent-yellow-40: hsl(55, 94%, 40%);
-    --accent-yellow-30: hsl(55, 94%, 30%);
-    --accent-yellow-20: hsl(55, 94%, 20%);
-
-    /* Neutral colors */
-    --neutral-color-100:hsl(0, 0%, 100%);
-    --neutral-color-90: hsl(200, 13%, 90%);
-    --neutral-color-80: hsl(200, 13%, 80%);
-    --neutral-color:    hsl(200, 13%, 70%);
-    --neutral-color-60: hsl(200, 13%, 60%);
-    --neutral-color-50: hsl(200, 13%, 50%);
-    --neutral-color-40: hsl(200, 13%, 40%);
-    --neutral-color-0:  hsl(0, 0%, 0%);
-}
-
-	@import url('https://fonts.cdnfonts.com/css/bariol-bold');
-</style>
-
 
 {@render children?.()}
 
 <style>
-	@font-face {
-		font-family: "Bariol";
-		src: url("$lib/assets/fonts/Bariol_Regular.otf") format("opentype");
-	}
+    :root {
+        /* Primary colors */
+        --primary-color-0: hsl(200, 43%, 0%);
+        --primary-color-10: hsl(200, 43%, 10%);
+        --primary-color: hsl(200, 43%, 20%);
+        --primary-color-30: hsl(200, 43%, 30%);
+        --primary-color-40: hsl(200, 43%, 40%);
+        --primary-color-50: hsl(200, 43%, 50%);
+        --primary-color-60: hsl(200, 43%, 60%);
+
+        /* Accent colors */
+        --accent-green-80: hsl(136, 100%, 80%);
+        --accent-green-70: hsl(136, 100%, 70%);
+        --accent-green-60: hsl(136, 100%, 60%);
+        --accent-green: hsl(136, 100%, 50%);
+        --accent-green-40: hsl(136, 100%, 40%);
+        --accent-green-30: hsl(136, 100%, 30%);
+        --accent-green-20: hsl(136, 100%, 20%);
+
+        --accent-red-90: hsl(357, 100%, 90%);
+        --accent-red-80: hsl(357, 100%, 80%);
+        --accent-red-70: hsl(357, 100%, 70%);
+        --accent-red: hsl(357, 100%, 60%);
+        --accent-red-50: hsl(357, 100%, 50%);
+        --accent-red-40: hsl(357, 100%, 40%);
+        --accent-red-30: hsl(357, 100%, 30%);
+
+        --accent-yellow-80: hsl(55, 94%, 80%);
+        --accent-yellow-70: hsl(55, 94%, 70%);
+        --accent-yellow-60: hsl(55, 94%, 60%);
+        --accent-yellow: hsl(55, 94%, 50%);
+        --accent-yellow-40: hsl(55, 94%, 40%);
+        --accent-yellow-30: hsl(55, 94%, 30%);
+        --accent-yellow-20: hsl(55, 94%, 20%);
+
+        /* Neutral colors */
+        --neutral-color-100: hsl(0, 0%, 100%);
+        --neutral-color-90: hsl(200, 13%, 90%);
+        --neutral-color-80: hsl(200, 13%, 80%);
+        --neutral-color: hsl(200, 13%, 70%);
+        --neutral-color-60: hsl(200, 13%, 60%);
+        --neutral-color-50: hsl(200, 13%, 50%);
+        --neutral-color-40: hsl(200, 13%, 40%);
+        --neutral-color-0: hsl(0, 0%, 0%);
+    }
+
+    @import url("https://fonts.cdnfonts.com/css/bariol-bold");
+
+    @font-face {
+        font-family: "Bariol";
+        src: url("$lib/assets/fonts/Bariol_Regular.otf") format("opentype");
+    }
 </style>


### PR DESCRIPTION
## What does this change?

Resolves issue #50. Removes duplicate style element by merging the contents of the style elements.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

I have ran the branch as a server and confirmed the error no longer shows up.

## How to review

Confirm the error has disappeared.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
