### PR TITLE
Feat: Capital letter in component link changed to small letter #160

### DIFF
--- a/src/lib/components/SortCard.svelte
+++ b/src/lib/components/SortCard.svelte
@@ -4,8 +4,8 @@
     import Arrow from './icons/Arrow.svelte'
 
     import Clock from './icons/Clock.svelte'
-    import Star from './icons/StarIcon.Svelte'
-    import Tomato from './icons/TomatoIcon.Svelte'
+    import Star from './icons/StarIcon.svelte'
+    import Tomato from './icons/TomatoIcon.svelte'
 
     export let icon
 </script>


### PR DESCRIPTION
## What does this change?

Resolves issue #160
Chanegd the captital letter in the component link to match the name of the component.

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()
