### PR TITLE
Feat: changed the name of the component in the link #162

### DIFF
--- a/src/lib/components/Card.svelte
+++ b/src/lib/components/Card.svelte
@@ -4,7 +4,7 @@
     import GridThree from '$lib/components/icons/Grid3Icon.svelte'
     import GridFour from '$lib/components/icons/Grid4Icon.svelte'
     import GridFive from '$lib/components/icons/Grid5Icon.svelte'
-    import List from '$lib/components/icons/ListViewIcon.svelte'
+    import List from '$lib/components/icons/ListviewIcon.svelte'
     import GroupIcon from './icons/GroupIcon.svelte'
     import Arrow from './icons/Arrow.svelte'
 


### PR DESCRIPTION
## What does this change?

Resolves issue #162 
Name of the component did not match the name of that component in the link. Now it does.


## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()
