### PR TITLE
155 routing from homepage

### DIFF
--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -112,7 +112,7 @@
 
     .left-icon-add {
         div {
-            display: block;
+            display: none;
         }
     }
 

--- a/src/lib/components/SnappMapPreview.svelte
+++ b/src/lib/components/SnappMapPreview.svelte
@@ -10,7 +10,7 @@
 
 <li>
     <div>
-        <a href={`/group/${groupID}/snappmap/${snappMap.uuid}`}>{snappMap.name}</a>
+        <a href={`/group/${groupID.uuid}/snappmap/${snappMap.uuid}`}>{snappMap.name}</a>
         <ul>
             <li><HeartIcon />15</li>
             <li><TomatoIcon />9</li>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,14 +6,20 @@
     const snappMaps = data.snappMaps
     const groups = data.groups
 
-    const snappMap = data.snappMaps[0]
+    const fourthGroup = data.groups[2]
+
+    const ThirdSnappMap = data.snappMaps[2]
+    const FourthSnappMap = data.snappMaps[3]
 </script>
 
 <Header page="home" active="home"/>
 
 
-<SnappMapPreview {snappMap}  groupID="217f68ac-44d3-4980-9914-9ef5f7649d8f"></SnappMapPreview>
+<SnappMapPreview snappMap={ThirdSnappMap}  groupID={fourthGroup}></SnappMapPreview>
+<SnappMapPreview snappMap={FourthSnappMap}  groupID={fourthGroup}></SnappMapPreview>
 
+
+<h2>You are in group <strong>{fourthGroup.name}</strong> </h2>
 
 <style>
     h1 {
@@ -21,5 +27,14 @@
         margin: 2rem auto;
         width: max-content;
         color: var(--neutral-color-darkest);
+    }
+    h2 {
+        display: flex;
+        justify-content: center;
+    }
+
+    strong {
+        color: var(--secondary-color);
+        margin-left: 1em;
     }
 </style>


### PR DESCRIPTION
## What does this change?

Routing from the homepage to the squad page is fixed. Now You are already In a 'group' which shows the snappmaps of the current group on the home page. The data is loaded manually. It only will show. the snappmaps of that current group.

Also the back button at the groups page is deleted.

Resolves issue #155 

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [X] [User test]()
- [] [Accessibility test]()
- [ ] [Performance test]()
- [X] [Responsive Design test]()
- [ ] [Device test]()
- [X] [Browser test]()

## Images

<img width="2594" height="1502" alt="image" src="https://github.com/user-attachments/assets/465e74ec-c6a6-48a7-afac-05dac1476f0e" />

